### PR TITLE
Added a toggleable feature for online vs all-time alt IP account checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@
 # AltShield Configuration
 max_accounts: 2 # Maximum accounts per IP
 max_ips: 3 # Maximum IPs per player
+count_online_only: false #Option to only count the players currently online for max accounts, requires a new database
 bypass_permission: "altshield.bypass"
 kick_message: "&cYou have reached the maximum accounts allowed on this IP!"
 messages:
-  reload: "&aAltShield configuration reloaded successfully!"\  bypass: "&e[AltShield] Allowing {player} (Has bypass permission)"
+reload: "&aAltShield configuration reloaded successfully!"\  bypass: "&e[AltShield] Allowing {player} (Has bypass permission)"
 ```
 
 ## 💾 Database

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.akatriggered'
-version = '1.21'
+version = '1.21.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/akatriggered/altShield/DatabaseManager.java
+++ b/src/main/java/com/akatriggered/altShield/DatabaseManager.java
@@ -58,4 +58,18 @@ public class DatabaseManager {
             e.printStackTrace();
         }
     }
+
+    public boolean playerExists(String uuid, String ip) {
+        String query = "SELECT 1 FROM player_data WHERE uuid = ? AND ip = ? LIMIT 1;";
+        try (PreparedStatement stmt = connection.prepareStatement(query)) {
+            stmt.setString(1, uuid);
+            stmt.setString(2, ip);
+            ResultSet rs = stmt.executeQuery();
+            return rs.next();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,8 +1,11 @@
 max_accounts: 2
 max_ips: 3
+#You must have a fresh database to change check_online_only
+check_online_only: false
 bypass_permission: "altshield.bypass"
 kick_message_accounts: "&cYou have reached the maximum accounts allowed on this IP!"
 kick_message_ips: "&cToo many accounts detected from your IP!"
+
 
 database:
   use-mysql: false


### PR DESCRIPTION
Adds a check_online_only option to config.yml allowing server owners to choose whether to limit the number of alt accounts per IP based on only currently online accounts (true) or all accounts that have ever joined from that IP (false). \